### PR TITLE
Bump version for node-geocoder

### DIFF
--- a/package.js
+++ b/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  'node-geocoder': '2.6.0'
+  'node-geocoder': '2.9.0'
 });
 
 Package.on_use(function(api) {


### PR DESCRIPTION
Bump version for node-geocoder.  2.9.0 was updated today. 

Thanks!
