### PR TITLE
Updated geocoder version to 2.14.0

### DIFF
--- a/package.js
+++ b/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Npm.depends({
-  'node-geocoder': '2.9.0'
+  'node-geocoder': '2.14.0'
 });
 
 Package.on_use(function(api) {


### PR DESCRIPTION
Updated package.js. Node-geocoder has been updated to v2.14.0, which includes OpenCage. Would like to give it a try.